### PR TITLE
also catch runtime errors

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/anime/impl/extension/tester/ExtensionTests.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/anime/impl/extension/tester/ExtensionTests.kt
@@ -97,7 +97,7 @@ class ExtensionTests(
                 printTitle("${test.name} TEST FAILED", barColor = RED)
                 if (configs.stopOnError)
                     exitProcess(-1)
-            } catch (e: Exception) {
+            } catch (e: Throwable) {
                 writeTestError(test, e)
                 logger.error("Test($test): ", e)
                 if (configs.stopOnError)
@@ -344,7 +344,7 @@ class ExtensionTests(
      * @param test The test that failed.
      * @param e The exception returned by the failed test.
      */
-    private fun writeTestError(test: TestsEnum, e: Exception) {
+    private fun writeTestError(test: TestsEnum, e: Throwable) {
         val result = ResultDto(null, e.toString(), false)
         setTestResult(test, result)
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/43830312/201530976-76f3dd25-83b3-48b1-ba0d-4e4e5dfac3f7.png)
this error for example crashes the program cause it's an `Error`, not an `Exception`.